### PR TITLE
fix: support `routeInteractive` event in engines

### DIFF
--- a/addon/mixins/route-interactivity.js
+++ b/addon/mixins/route-interactivity.js
@@ -72,7 +72,7 @@ export default Mixin.create(IsFastbootMixin, {
     let isInteractive = this.isInteractive ? run.bind(this, this.isInteractive) : null;
     let options = {
       isInteractive,
-      name: this.get('routeName')
+      name: this.get('fullRouteName')
     };
 
     this.set('_monitoringInteractivity', true);
@@ -108,7 +108,7 @@ export default Mixin.create(IsFastbootMixin, {
     let baseData = {
       event: `route${phase}`,
       destination: targetName,
-      routeName: this.get('routeName'),
+      routeName: this.get('fullRouteName'),
       lostVisibility: this.get('documentVisibility.lostVisibility'),
       clientTime: getTimeAsFloat()
     };
@@ -141,7 +141,7 @@ export default Mixin.create(IsFastbootMixin, {
       };
     }
 
-    let routeName = this.get('routeName');
+    let routeName = this.get('fullRouteName');
     this._markTimeline(INTERACTIVE_LABEL);
     this._sendTransitionEvent('Interactive', routeName, data);
     hasFirstTransitionCompleted = true;
@@ -170,7 +170,7 @@ export default Mixin.create(IsFastbootMixin, {
    * @return {boolean} True if this route is the target of the current transition
    */
   _isLeafRoute(transition = this.get('_latestTransition')) {
-    return transition && transition.targetName === this.get('routeName');
+    return transition && transition.targetName === this.get('fullRouteName');
   },
 
   /**
@@ -183,7 +183,7 @@ export default Mixin.create(IsFastbootMixin, {
    * @return {string} The timeline label
    */
   _getTimelineLabel(type) {
-    return `Route ${type}: ${this.get('routeName')}`;
+    return `Route ${type}: ${this.get('fullRouteName')}`;
   },
 
   /**

--- a/tests/unit/mixins/route-interactivity-test.js
+++ b/tests/unit/mixins/route-interactivity-test.js
@@ -35,7 +35,7 @@ module('Unit | Mixin | route interactivity', function (hooks) {
 
   hooks.beforeEach(function () {
     this.BaseObject = EmberObject.extend(RouteInteractivityMixin, {
-      routeName: ROUTE_NAME,
+      fullRouteName: ROUTE_NAME,
       criticalComponents: CRITICAL_COMPONENTS,
       documentVisibility: VisibilityStub.create(),
       interactivity: InteractivityStub.create(),


### PR DESCRIPTION
If the "leaf" route is inside an engine, `transition.targetName === this.get('routeName')` will never be true. This circumvents the `didTransition` hook and prevents the `routeInteractive` event from firing.

`fullRouteName` includes the engine prefix, if applicable: https://github.com/emberjs/ember.js/blob/4790fb207c13bdb259451bd5236d572950040ca7/packages/ember-routing/lib/system/route.js#L145

This should be backwards compatible, as `fullRouteName === routeName` for non-engine routes.

(fullRouteName was introduced in 2.10 ... I'm also opening a PR to document it.)